### PR TITLE
[FIX] sale_service_recurrence_configurator: When selecting a template…

### DIFF
--- a/sale_service_recurrence_configurator/models/sale.py
+++ b/sale_service_recurrence_configurator/models/sale.py
@@ -68,6 +68,7 @@ class SaleOrder(models.Model):
             'july': template.july,
             'august': template.august,
             'september': template.september,
+            'october': template.october,
             'november': template.november,
             'december': template.december,
             'week1': template.week1,


### PR DESCRIPTION
… in sale order, bring the October information.
Al seleccionar una plantilla en los pedidos de venta, traer la información de Octubre a las líneas del pedido de venta.