### PR TITLE
[FIX] sale_order_renovate_contract: Fix recurring next date calculati…

### DIFF
--- a/sale_order_renovate_contract/__openerp__.py
+++ b/sale_order_renovate_contract/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Sale Order Renovate Contract",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "http://www.avanzosc.es",

--- a/sale_order_renovate_contract/models/account_analytic_account.py
+++ b/sale_order_renovate_contract/models/account_analytic_account.py
@@ -34,6 +34,11 @@ class AccountAnalyticAccount(models.Model):
                     lambda x: x.price_unit):
                 line.price_unit = (line.price_unit +
                                    (line.price_unit * increase))
+        if (self.recurring_rule_type == 'monthly' and
+                self.recurring_interval > 1):
+            self.recurring_next_date = (
+                fields.Date.from_string(self.date_start) +
+                relativedelta(months=self.recurring_interval - 1))
         self.set_open()
         if origin_sale:
             self._duplicate_sale_order_from_contract(origin_sale,

--- a/sale_order_renovate_contract/tests/test_sale_order_renovate_contract.py
+++ b/sale_order_renovate_contract/tests/test_sale_order_renovate_contract.py
@@ -25,7 +25,7 @@ class TestSaleOrderRenovateContract(common.TransactionCase):
                         'date': '2025-12-31',
                         'type': 'contract',
                         'recurring_invoices': True,
-                        'recurring_interval': 1,
+                        'recurring_interval': 3,
                         'recurring_rule_type': 'monthly',
                         'recurring_next_date': '2025-01-15',
                         'recurring_invoice_line_ids': [(0, 0, line_vals)]}
@@ -83,6 +83,9 @@ class TestSaleOrderRenovateContract(common.TransactionCase):
         self.assertEqual(
             account.date, '2026-12-31',
             'Error in date end of renovate contract')
+        self.assertEqual(
+            account.recurring_next_date, '2026-03-01',
+            'Error in recurring next date of renovate contract')
         cond = [('project_id', '=', account.id)]
         sale = self.sale_model.search(cond, limit=1)
         self.assertNotEqual(len([sale]), 0, 'New sale not found')


### PR DESCRIPTION
…on in the new contract.
En el nuevo contrato generado, arreglar el cálculo de la fecha de la siguiente generación de factura, cuando se renueva "mensualmente", y con un intervalo mayor que 1.