### PR TITLE
[FIX] sale_order_line_amount_control: raise error if only it is equal to

### DIFF
--- a/sale_order_line_amount_control/models/sale_order.py
+++ b/sale_order_line_amount_control/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
         for sale in self:
             min_price_unit = sale._get_min_price_unit()
             lines = sale.order_line.filtered(
-                lambda x: x.price_unit <= min_price_unit)
+                lambda x: x.price_unit == min_price_unit)
             if lines:
                 raise UserError(
                     _('You have %s line(s) with an amount less than or equal '


### PR DESCRIPTION
minimun price