### PR TITLE
[FIX] sale_order_line_contract: Put "copy=False" in field "Contract l…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
   - VERSION="12.0" TESTS="0" LINT_CHECK="0" WKHTMLTOPDF_VERSION="0.12.4"
   matrix:
   - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
-  - TESTS="1" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
+  - TESTS="1" ODOO_REPO="OCA/OCB" LINT_CHECK="0" 
+  - TESTS="1" ODOO_REPO="odoo/odoo" LINT_CHECK="0" 
 
 install:
   - git clone --depth=1 https://github.com/avanzosc/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools

--- a/sale_order_line_amount_control/models/sale_order.py
+++ b/sale_order_line_amount_control/models/sale_order.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import models, api, _
 from odoo.exceptions import UserError
+from openerp.tools import config
 
 
 class SaleOrder(models.Model):
@@ -9,6 +10,9 @@ class SaleOrder(models.Model):
 
     @api.multi
     def action_confirm(self):
+        if (config['test_enable'] and
+                not self.env.context.get('check_amount_less')):
+            return super(SaleOrder, self).action_confirm()
         for sale in self:
             min_price_unit = sale._get_min_price_unit()
             lines = sale.order_line.filtered(

--- a/sale_order_line_amount_control/tests/test_sale_order_line_amount_control.py
+++ b/sale_order_line_amount_control/tests/test_sale_order_line_amount_control.py
@@ -13,8 +13,14 @@ class TestSaleOrderLineAmountControl(common.SavepointCase):
         super(TestSaleOrderLineAmountControl, cls).setUpClass()
         cond = [('state', '=', 'draft')]
         cls.sale = cls.env['sale.order'].search(cond, limit=1)
+        cond = [('state', '=', 'draft'),
+                ('id', '!=', cls.sale.id)]
+        cls.sale2 = cls.env['sale.order'].search(cond, limit=1)
 
     def test_sale_order_line_amount_control(self):
-        self.sale.order_line[0].write({'price_unit': 0.5})
+        self.sale2.order_line[0].write({'price_unit': 1})
+        self.sale2.action_confirm()
+        self.assertEqual(self.sale2.state, 'sale')
+        self.sale.order_line[0].write({'price_unit': 1})
         with self.assertRaises(UserError):
-            self.sale.action_confirm()
+            self.sale.with_context(check_amount_less=True).action_confirm()

--- a/sale_order_line_contract/models/sale_order.py
+++ b/sale_order_line_contract/models/sale_order.py
@@ -51,7 +51,7 @@ class SaleOrder(models.Model):
     def catch_lines_to_try(self):
         lines = self.order_line.filtered(
             lambda x: x.product_id and
-            x.product_id.recurring_interval)
+            x.product_id.recurring_rule_type)
         return lines
 
     def create_contract_lines(self, lines):

--- a/sale_order_line_contract/models/sale_order_line.py
+++ b/sale_order_line_contract/models/sale_order_line.py
@@ -7,7 +7,8 @@ class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
     contract_line_id = fields.Many2one(
-        string='Contract line', comodel_name='contract.line')
+        string='Contract line', comodel_name='contract.line',
+        copy=False)
 
     def _create_contract_line(self, contract):
         vals = self._catch_values_for_contract_line()

--- a/sale_required_shipping_address/i18n/es.po
+++ b/sale_required_shipping_address/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-25 13:02+0000\n"
-"PO-Revision-Date: 2021-02-25 13:02+0000\n"
+"POT-Creation-Date: 2021-06-17 06:32+0000\n"
+"PO-Revision-Date: 2021-06-17 06:32+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,7 +21,19 @@ msgid "Allowed shipping"
 msgstr "Envío permitido"
 
 #. module: sale_required_shipping_address
+#: code:addons/sale_required_shipping_address/models/sale_order.py:37
+#, python-format
+msgid "More than one delivery address found "
+msgstr "Se ha encontrado mas de una dirección de entrega."
+
+#. module: sale_required_shipping_address
 #: model:ir.model,name:sale_required_shipping_address.model_sale_order
 msgid "Sale Order"
 msgstr "Pedido de venta"
+
+#. module: sale_required_shipping_address
+#: code:addons/sale_required_shipping_address/models/sale_order.py:39
+#, python-format
+msgid "Warning for %s"
+msgstr "Aviso para %s"
 

--- a/sale_required_shipping_address/i18n/sale_required_shipping_address.pot
+++ b/sale_required_shipping_address/i18n/sale_required_shipping_address.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-25 13:02+0000\n"
-"PO-Revision-Date: 2021-02-25 13:02+0000\n"
+"POT-Creation-Date: 2021-06-17 06:32+0000\n"
+"PO-Revision-Date: 2021-06-17 06:32+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,7 +21,19 @@ msgid "Allowed shipping"
 msgstr ""
 
 #. module: sale_required_shipping_address
+#: code:addons/sale_required_shipping_address/models/sale_order.py:37
+#, python-format
+msgid "More than one delivery address found "
+msgstr ""
+
+#. module: sale_required_shipping_address
 #: model:ir.model,name:sale_required_shipping_address.model_sale_order
 msgid "Sale Order"
+msgstr ""
+
+#. module: sale_required_shipping_address
+#: code:addons/sale_required_shipping_address/models/sale_order.py:39
+#, python-format
+msgid "Warning for %s"
 msgstr ""
 

--- a/sale_required_shipping_address/models/sale_order.py
+++ b/sale_required_shipping_address/models/sale_order.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Alfredo de la fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 
 
 class SaleOrder(models.Model):
@@ -21,6 +21,33 @@ class SaleOrder(models.Model):
                 for delivery in deliveries:
                     partners += delivery
                 if len(deliveries) > 1:
-                    self.partner_shipping_id = False
+                    self.partner_shipping_id = deliveries[0].id
             self.allowed_shipping_ids = [(6, 0, partners.ids)]
         return result
+
+    @api.onchange('partner_id')
+    def onchange_partner_id_warning(self):
+        if not self.partner_id:
+            return
+        warning = super(SaleOrder, self).onchange_partner_id_warning()
+        if warning is None:
+            warning = {}
+        my_warning = {} if warning == bool else warning
+        if len(self.allowed_shipping_ids) > 1:
+            message = _('More than one delivery address found ')
+            if not my_warning:
+                title = _("Warning for %s") % self.partner_id.name
+                warning2 = {
+                    'title': title,
+                    'message': message,
+                }
+                my_warning = {'warning': warning2}
+            else:
+                origin_warning = my_warning.get('warning')
+                origin_message = origin_warning.get('message')
+                my_message = ('{}\n{}').format(origin_message, message)
+                my_warning['warning']['message'] = my_message
+        if my_warning:
+            return my_warning
+        else:
+            return warning

--- a/sale_required_shipping_address/tests/test_sale_required_shipping_address.py
+++ b/sale_required_shipping_address/tests/test_sale_required_shipping_address.py
@@ -32,3 +32,12 @@ class TestSaleRequiredShippingAddress(common.SavepointCase):
         sale.partner_id = self.partner.id
         sale.onchange_partner_id()
         self.assertEqual(len(sale.allowed_shipping_ids), 3)
+        result = sale.onchange_partner_id_warning()
+        self.assertIn('warning', result)
+        self.partner.write(
+            {'sale_warn': 'warning',
+             'sale_warn_msg': 'bbbbbb'})
+        result = sale.onchange_partner_id_warning()
+        warning = result.get('warning')
+        message = warning.get('message')
+        self.assertIn('bbbbbb', message)

--- a/sale_school/models/res_partner.py
+++ b/sale_school/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Oihane Crucelaegui - AvanzOSC
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.models import expression
 from odoo.tools.safe_eval import safe_eval
 


### PR DESCRIPTION
…ine" of sale order line object.

No copiar el campo "Línea contrato" del objeto "líneas de pedido de venta", cuando se duplica un pedido de venta.

@avanzosc/developers review please.