### PR TITLE
[14.0][FIX] sale_order_emptying_location: In Sale order, adjust so that the Button_empty_location button

### DIFF
--- a/sale_order_emptying_location/__manifest__.py
+++ b/sale_order_emptying_location/__manifest__.py
@@ -11,6 +11,7 @@
     "depends": [
         "sale_order_type_picking",
         "sale_order_lot_selection",
+        "stock_picking_emptying_location",
     ],
     "data": [
         "views/sale_order_view.xml",

--- a/sale_order_emptying_location/models/sale_order.py
+++ b/sale_order_emptying_location/models/sale_order.py
@@ -28,7 +28,7 @@ class SaleOrder(models.Model):
                 and sale.type_id.picking_type_id.default_location_src_id
                 and sale.state == "draft"
             ):
-                show_empty_location = True
+                show_empty_location = sale.type_id.picking_type_id.show_empty_location
             sale.show_empty_location = show_empty_location
 
     def button_empty_location(self):


### PR DESCRIPTION
In Sale order, adjust so that the Button_empty_location button is only visible if the "Operation Type" has the "Show empty location" check box enabled.